### PR TITLE
Remove i form 'yarn'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,32 +1,32 @@
 name: React App CI
 # Controls when the action will run.
 on:
-    # Triggers the workflow on push or pull request events but only for the main branch
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-    react-app-workflow:
-        # The type of runner that the job will run on
-        runs-on: ubuntu-latest
-        # Steps represent a sequence of tasks that will be executed as part of the job
-        steps:
-            - uses: actions/checkout@v2
-            - name: Use Node.js 14.x
-              uses: actions/setup-node@v2
-              with:
-                  node-version: 14.x
-            - name: yarn i
-              run: yarn i
-            - name: test
-              run: yarn test
-            - name: format
-              run: yarn run prettier
-            - name: lint
-              run: yarn run lint
-            - name: typescript
-              run: yarn run typescript
-            - name: build
-              run: yarn run build --if-present
+  react-app-workflow:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: yarn
+        run: yarn
+      - name: test
+        run: yarn test
+      - name: format
+        run: yarn run prettier
+      - name: lint
+        run: yarn run lint
+      - name: typescript
+        run: yarn run typescript
+      - name: build
+        run: yarn run build --if-present

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 const App = () => {
-  return <div>App</div>
+  return <div data-testid="app">App</div>
 }
 
 export default App

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import App from './App'
+
+describe('<App />', () => {
+  afterEach(cleanup)
+
+  it('renders without crashing', async () => {
+    const { findByTestId } = render(<App />)
+    const app = await findByTestId('app')
+
+    expect(app).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This pull request is for removing the "i" from the command "yarn i" which was causing an error during the continuous integration (CI) build process. The command "yarn i" is not a valid command, the correct command is yarn install or just yarn which will install all the dependencies from the package.json file.